### PR TITLE
fix(packages): update treesitter to comparable version 0.25.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,15 +18,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 19
+          node-version: 24
       - name: Install rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.83
+          toolchain: 1.95
           override: true
           components: clippy, rustfmt
       - name: Install Tree sitter CLI
-        run: cargo install tree-sitter-cli
+        run: cargo install tree-sitter-cli@0.25.10
       - name: Install dependencies
         run: npm install
       - name: Tree sitter generate parser and run grammar tests

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "prebuildify": "^6.0.1",
-    "tree-sitter-cli": "^0.24.7"
+    "tree-sitter-cli": "~0.25.10"
   },
   "tree-sitter": [
     {


### PR DESCRIPTION
According to https://github.com/kcl-lang/tree-sitter-kcl/actions/runs/24554750482/job/71792915244 the latest versions 0.26.x are not compatible with the Rust edition referenced in `Cargo.toml`. Updating to their latest 0.25.x version that is compatible.